### PR TITLE
Fix titles & add pre-Divine Potion notification

### DIFF
--- a/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesConfig.java
+++ b/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesConfig.java
@@ -204,10 +204,34 @@ public interface NotificationMessagesConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "preDivinePotion",
+		name = "Pre-Divine Potion expiration",
+		description = "Notifies you before your divine potion expires",
+		position = 13,
+		section = potionSection
+	)
+	default boolean preDivinePotion()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "preDivinePotionMessage",
+		name = "Pre-Divine Potion notification message",
+		description = "The message with which to notify you before a divine potion's expiration",
+		position = 14,
+		section = potionSection
+	)
+	default String preDivinePotionMessage()
+	{
+		return "Your Divine potion is about to expire!";
+	}
+
+	@ConfigItem(
 		keyName = "overloadNotification",
 		name = "Overload expiration",
 		description = "Notifies you when your Overload expires",
-		position = 13,
+		position = 15,
 		section = potionSection
 	)
 	default boolean overloadNotification()
@@ -219,7 +243,7 @@ public interface NotificationMessagesConfig extends Config
 		keyName = "overloadMessage",
 		name = "Overload notification message",
 		description = "The message with which to notify you of an Overload's expiration",
-		position = 14,
+		position = 16,
 		section = potionSection
 	)
 	default String overloadMessage()
@@ -231,7 +255,7 @@ public interface NotificationMessagesConfig extends Config
 		keyName = "staminaNotification",
 		name = "Stamina expiration",
 		description = "Notifies you when your stamina potion expires",
-		position = 15,
+		position = 17,
 		section = potionSection
 	)
 	default boolean staminaNotification()
@@ -243,7 +267,7 @@ public interface NotificationMessagesConfig extends Config
 		keyName = "staminaMessage",
 		name = "Stamina notification message",
 		description = "The message with which to notify you of a stamina potion's expiration",
-		position = 16,
+		position = 18,
 		section = potionSection
 	)
 	default String staminaMessage()
@@ -255,7 +279,7 @@ public interface NotificationMessagesConfig extends Config
 		keyName = "imbuedHeartNotification",
 		name = "Imbued Heart notification",
 		description = "Notifies you when your Imbued heart has regained its power",
-		position = 17,
+		position = 19,
 		section = potionSection
 	)
 	default boolean imbuedHeartNotification()
@@ -267,7 +291,7 @@ public interface NotificationMessagesConfig extends Config
 		keyName = "imbuedHeartMessage",
 		name = "Imbued Heart notification message",
 		description = "The message with which to notify you of an Imbued heart's reinvigoration",
-		position = 18,
+		position = 20,
 		section = potionSection
 	)
 	default String imbuedHeartMessage()

--- a/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesNotifier.java
+++ b/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesNotifier.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Player;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.chat.ChatColorType;
@@ -157,7 +158,7 @@ public class NotificationMessagesNotifier
                 break;
         }
 
-        sendNotification(appName, message, type);
+        sendNotification(buildTitle(), message, type);
 
         switch (runeLiteConfig.notificationSound())
         {
@@ -183,6 +184,23 @@ public class NotificationMessagesNotifier
                 .build());
         }
         log.debug(message);
+    }
+
+    private String buildTitle()
+    {
+        Player player = client.getLocalPlayer();
+        if (player == null)
+        {
+            return appName;
+        }
+
+        String name = player.getName();
+        if (Strings.isNullOrEmpty(name))
+        {
+            return appName;
+        }
+
+        return appName + " - " + name;
     }
 
     private void sendNotification(

--- a/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesPlugin.java
+++ b/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesPlugin.java
@@ -33,6 +33,9 @@ public class NotificationMessagesPlugin extends Plugin
 	private static final String SUPER_ANTIFIRE = "Your super antifire potion has expired.";
 	private static final String ANTIPOISON = "Your poison resistance has worn off.";
 	private static final String DIVINE_POTION = "The effects of the divine potion have worn off";
+	private static final String PRE_DIVINE_POTION = "Your divine potion effect is about to expire.";
+	private static final String PRE_DIVINE_RANGE = "Your divine ranging potion is about to expire.";
+	private static final String PRE_DIVINE_MAGE = "Your divine magic potion is about to expire.";
 	private static final String OVERLOAD = "The effects of overload have worn off, and you feel normal again.";
 	private static final String STAMINA = "Your stamina enhancement has expired.";
 	private static final String IMBUED_HEART = "Your imbued heart has regained its magical power.";
@@ -112,6 +115,13 @@ public class NotificationMessagesPlugin extends Plugin
 						notifier.notify(config.divinePotionMessage());
 					}
 				}
+				if (chatMessage.getMessage().contains(PRE_DIVINE_POTION) || chatMessage.getMessage().contains(PRE_DIVINE_RANGE) || chatMessage.getMessage().contains(PRE_DIVINE_MAGE))
+				{
+					if (config.preDivinePotion())
+					{
+						notifier.notify(config.preDivinePotionMessage());
+					}
+				}
 				if (chatMessage.getMessage().contains(OVERLOAD))
 				{
 					if (config.overloadNotification())
@@ -150,11 +160,11 @@ public class NotificationMessagesPlugin extends Plugin
 					}
 				}
 				break;
-			/*case FRIENDSCHAT:
+			case FRIENDSCHAT:
 				if (chatMessage.getMessage().contains("Test"))
 				{
 					notifier.notify("ALERT: THIS IS A TEST");
-				}*/
+				}
 			}
 	}
 }


### PR DESCRIPTION
1. Set the title of notifications to e.g. "RuneLite - Username" when logged in, for consistency with the base notifications plugin. Code is pulled directly from the base RuneLite notifications plugin.

2. Add "pre-Divine Potion expiration" notification, since it generates a chat message and we already have a "Divine Potion expiration" and "pre-Antifire expiration" option. Useful for maintaining 100% uptime on divine potions, which is important since they go from +19 to +0 in one tick.