### PR TITLE
Added muting sounds by ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.20-SNAPSHOT'
+def runeLiteVersion = '1.7.24'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.brooklyn'
-version = '1.7'
+version = '1.8'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMuteConfig.java
+++ b/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMuteConfig.java
@@ -876,5 +876,17 @@ public interface AnnoyanceMuteConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+			keyName = "soundsToMute",
+			name = "Muted Sounds",
+			description = "Enter IDs of the sounds you wish to mute",
+			position = 28
+	)
+	default String soundsToMute()
+	{
+		return "";
+	}
+
+
 
 }

--- a/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
+++ b/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
@@ -37,6 +37,10 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.Text;
+
+import java.util.Collections;
+import java.util.List;
 
 @PluginDescriptor(
 	name = "Annoyance Mute",
@@ -105,6 +109,11 @@ public class AnnoyanceMutePlugin extends Plugin
 
 	private boolean shouldMute(int soundId)
 	{
+		if (getSelectedSounds().contains(Integer.toString(soundId)))
+		{
+			return true;
+		}
+
 		switch (soundId)
 		{
 			// ------- Combat -------
@@ -345,5 +354,17 @@ public class AnnoyanceMutePlugin extends Plugin
 			default:
 				return false;
 		}
+	}
+
+	List<String> getSelectedSounds()
+	{
+		final String configSounds = config.soundsToMute().toLowerCase();
+
+		if (configSounds.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		return Text.fromCSV(configSounds);
 	}
 }


### PR DESCRIPTION
Added an option so that users can add sounds to mute by their ID (can be obtained using the Visualize Sounds plugin also on the plugin hub).