### PR TITLE
Fix to use runelite config values

### DIFF
--- a/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesNotifier.java
+++ b/src/main/java/com/brooklyn/notificationmessages/NotificationMessagesNotifier.java
@@ -148,6 +148,11 @@ public class NotificationMessagesNotifier
     {
         eventBus.post(new NotificationFired(message, type));
 
+	if (!runeLiteConfig.sendNotificationsWhenFocused() && clientUI.isFocused())
+	{
+		return;
+	}	    
+	    
         switch (runeLiteConfig.notificationRequestFocus())
         {
             case REQUEST:
@@ -158,7 +163,10 @@ public class NotificationMessagesNotifier
                 break;
         }
 
-        sendNotification(buildTitle(), message, type);
+	if (runeLiteConfig.enableTrayNotifications())
+	{
+		sendNotification(buildTitle(), message, type);
+	}
 
         switch (runeLiteConfig.notificationSound())
         {


### PR DESCRIPTION
The config values for disabling notifications when focused as well as not always using tray notifications is not used. This patch uses the runelite config values, basically the code is from Notifier.java

Not sure why you are using your own notifier code but this should resolve the issue with the config values not being used