### PR TITLE
Add new option for verzik p2 mute

### DIFF
--- a/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMuteConfig.java
+++ b/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMuteConfig.java
@@ -909,6 +909,14 @@ public interface AnnoyanceMuteConfig extends Config
 		return "";
 	}
 
-
-
+	@ConfigItem(
+			keyName = "muteVerzikP2MageAttack",
+			name = "Verzik P2 Mage Attack",
+			description = "Mutes the sounds of Verzik P2 Mage Attack",
+			section = combatSection
+	)
+	default boolean muteVerzikP2MageAttack()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
+++ b/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
@@ -140,6 +140,9 @@ public class AnnoyanceMutePlugin extends Plugin
 			case SoundEffectID.ZOMBIE_THRALL_ATTACK:
 				return config.muteThralls();
 
+			case SoundEffectID.TOB_VERZIK_VAMPIRE_MAGIC_ATTACK:
+				return config.muteVerzikP2MageAttack();
+
 			// ------- NPCs -------
 
 			case SoundEffectID.CAVE_HORROR:

--- a/src/main/java/com/brooklyn/annoyancemute/SoundEffectID.java
+++ b/src/main/java/com/brooklyn/annoyancemute/SoundEffectID.java
@@ -238,4 +238,7 @@ public final class SoundEffectID
 	protected static final int CHARGE_AIR_ORB = 116;
 	protected static final int CHARGE_FIRE_ORB = 117;
 	protected static final int CHARGE_WATER_ORB = 118;
+
+	// TOB
+	protected static final int TOB_VERZIK_VAMPIRE_MAGIC_ATTACK = 3987;
 }


### PR DESCRIPTION
New verzik p2 attack sounds were added with this update: https://oldschool.runescape.wiki/w/Update:A_Night_At_The_Theatre_Rework. Example of the old sounds here: https://www.youtube.com/watch?v=jNbOC7BIPXs&ab_channel=GranddadJad (ignore that it's on the p2 trainer, the sounds are correct to old verzik). New sounds here: https://youtu.be/olDqj5My_LA?t=193.

Tested in entry mode (sounds are the same regardless of tob mode).

Addresses issue #44 