### PR TITLE
Fix Teleport (only others)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.brooklyn'
-version = '1.8.5'
+version = '1.8.6'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/brooklyn/annoyancemute/SoundEffect.java
+++ b/src/main/java/com/brooklyn/annoyancemute/SoundEffect.java
@@ -20,9 +20,14 @@ public class SoundEffect
 		this.animID = animID;
 	}
 
+
+	// this is more of an "equals enough" type of equals where we care if either side's type is EITHER
+	// it also checks the animation id of the item set in the hashset of SoundEffects and checks if it's -1 or matches current player.
 	@Override
 	public boolean equals(Object obj)
 	{
+		// this refers to an item found in the sound effects hashset being compared to
+		// obj refers to the SoundEffect created to based on the sound, type and current animation of the player
 		if (obj == null) {
 			return false;
 		}
@@ -41,15 +46,15 @@ public class SoundEffect
 		if (this.type.equals(SoundEffectType.Either))
 		{
 			// if the animID is -1 it means it should be muted because the sound is a default mute
-			// if the animID is not -1 it means we're caring about local player animation to determine mute
-			// this is only valid for muting Teleports (only others)
-			if (other.animID == -1 || this.animID == -1)
+			if (this.animID == -1)
 			{
 				return true;
 			}
-			if (other.animID == this.animID)
+			// if the animID is not -1 it means we're caring about local player animation to determine mute
+			// this is only valid for muting Teleports (only others)
+			if (other.animID != this.animID)
 			{
-				return false;
+				return true;
 			}
 		}
 


### PR DESCRIPTION
Before the check on the animID check made it so that when doing an animation it allowed teleport (only others) still played, whoops.