### PR TITLE
Change shouldMute compare

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.brooklyn'
-version = '1.8.7'
+version = '1.8.8'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
+++ b/src/main/java/com/brooklyn/annoyancemute/AnnoyanceMutePlugin.java
@@ -25,9 +25,11 @@
 package com.brooklyn.annoyancemute;
 
 import com.google.inject.Provides;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
@@ -528,7 +530,19 @@ public class AnnoyanceMutePlugin extends Plugin
 			return true;
 		}
 
-		return soundEffects.stream().anyMatch(s -> s.equals(soundEffect));
+		List<SoundEffect> filteredSoundEffects = soundEffects.stream().filter(
+			s -> s.id == soundEffect.id
+			&& (s.type == SoundEffectType.Either || s.type == soundEffect.type)
+		).collect(Collectors.toCollection(ArrayList::new));
+		
+		if (filteredSoundEffects.size() == 0)
+		{
+			return false;
+		}
+		else
+		{
+			return filteredSoundEffects.stream().anyMatch(s -> s.animID == -1) || filteredSoundEffects.stream().noneMatch(s -> s.animID == soundEffect.animID);
+		}
 	}
 
 	List<String> getSelectedSounds()

--- a/src/main/java/com/brooklyn/annoyancemute/SoundEffect.java
+++ b/src/main/java/com/brooklyn/annoyancemute/SoundEffect.java
@@ -19,45 +19,4 @@ public class SoundEffect
 		this.type = type;
 		this.animID = animID;
 	}
-
-
-	// this is more of an "equals enough" type of equals where we care if either side's type is EITHER
-	// it also checks the animation id of the item set in the hashset of SoundEffects and checks if it's -1 or matches current player.
-	@Override
-	public boolean equals(Object obj)
-	{
-		// this refers to an item found in the sound effects hashset being compared to
-		// obj refers to the SoundEffect created to based on the sound, type and current animation of the player
-		if (obj == null) {
-			return false;
-		}
-
-		if (obj.getClass() != this.getClass()) {
-			return false;
-		}
-
-		final SoundEffect other = (SoundEffect) obj;
-
-		if (other.id != this.id)
-		{
-			return false;
-		}
-
-		if (this.type.equals(SoundEffectType.Either))
-		{
-			// if the animID is -1 it means it should be muted because the sound is a default mute
-			if (this.animID == -1)
-			{
-				return true;
-			}
-			// if the animID is not -1 it means we're caring about local player animation to determine mute
-			// this is only valid for muting Teleports (only others)
-			if (other.animID != this.animID)
-			{
-				return true;
-			}
-		}
-
-		return this.type.equals(other.type);
-	}
 }


### PR DESCRIPTION
Move from using the SoundEffect equals to compare  to filtering the HashSet on shouldMute.

I couldn't figure out how to get the equals() override to behave the way I have it now.