### PR TITLE
Add Colosseum to Minigames

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Configs can be individually disabled if you do not wish to enable Smart Metronom
 * Pyramid Plunder
 * Tithe Farm
 * Volcanic Mine
+* Colosseum
 
 ### Raids
 * Chambers of Xeric

--- a/src/main/java/com/brooklyn/smartmetronome/SmartMetronomeConfig.java
+++ b/src/main/java/com/brooklyn/smartmetronome/SmartMetronomeConfig.java
@@ -406,6 +406,17 @@ public interface SmartMetronomeConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "colosseumMetronome",
+		name = "Colosseum",
+		description = ENABLES + "in the Colosseum",
+		section = minigamesSection
+	)
+	default boolean colosseumMetronome()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "fightCaveMetronome",
 		name = "Fight Cave",
 		description = ENABLES + "in the Tzhaar Fight Cave",

--- a/src/main/java/com/brooklyn/smartmetronome/SmartMetronomePlugin.java
+++ b/src/main/java/com/brooklyn/smartmetronome/SmartMetronomePlugin.java
@@ -312,6 +312,10 @@ public class SmartMetronomePlugin extends Plugin
 		15263, 15262
 	);
 
+	private static final Set<Integer> COLOSSEUM_REGIONS = ImmutableSet.of(
+		7216
+	);
+
 	// Slayer
 
 	private static final Set<Integer> SLAYER_TOWER_REGIONS = ImmutableSet.of(
@@ -620,6 +624,11 @@ public class SmartMetronomePlugin extends Plugin
 			}
 
 			else if (config.volcanicMineMetronome() && VOLCANIC_MINE_REGIONS.contains(mapregion))
+			{
+				return true;
+			}
+
+			else if (config.colosseumMetronome() && COLOSSEUM_REGIONS.contains(mapregion))
 			{
 				return true;
 			}

--- a/src/main/java/com/brooklyn/smartmetronome/SmartMetronomePlugin.java
+++ b/src/main/java/com/brooklyn/smartmetronome/SmartMetronomePlugin.java
@@ -339,7 +339,8 @@ public class SmartMetronomePlugin extends Plugin
 		6710, 6711, 6965, 6966, 6967, 6968, 7221, 7223, 7224, 7478, 7479, // Tithe Farm
 		15008, 15264, 15519, 15775, // Volcanic Mine
 		6205, 6461, 6717, // Wintertodt
-		8495, 8496, 8751, 8752, 9008, 9263, 9264, 9265 // Zulrah
+		8495, 8496, 8751, 8752, 9008, 9263, 9264, 9265, // Zulrah
+		6960, 6704, 6705, 6961, 7217, 7472, 7215, 6959, 6703 // Colosseum
 	);
 
 	public void setMetronome()


### PR DESCRIPTION
Adds Colosseum to smart metronome with appropriate mute regions (still a little un-needed tocking when entering the Col, but from testing the plugin in other regions I believe this is unavoidable with the way the plugin is currently setup).